### PR TITLE
Close connection

### DIFF
--- a/lib/yajl/http_stream.rb
+++ b/lib/yajl/http_stream.rb
@@ -101,6 +101,7 @@ module Yajl
         socket = opts.has_key?(:socket) ? opts.delete(:socket) : TCPSocket.new(uri.host, uri.port)
         request = "#{method} #{uri.path}#{uri.query ? "?"+uri.query : nil} HTTP/1.1\r\n"
         request << "Host: #{uri.host}\r\n"
+        request << "Connection: close\r\n"
         request << "Authorization: Basic #{[uri.userinfo].pack('m').strip!}\r\n" unless uri.userinfo.nil?
         request << "User-Agent: #{user_agent}\r\n"
         request << "Accept: */*\r\n"


### PR DESCRIPTION
This (tiny) patch adds the "Connection: close" header to the HTTP request that HttpStream makes. It instructs the server to close the connection after sending the response rather than wait for further requests from the client.
