### PR TITLE
Add benchmark for streaming psych

### DIFF
--- a/benchmark/encode.rb
+++ b/benchmark/encode.rb
@@ -52,7 +52,7 @@ Benchmark.bmbm { |x|
       }
     }
     x.report("Psych::JSON::Stream") {
-        times.times {
+      times.times {
         io = StringIO.new
         stream = Psych::JSON::Stream.new io
         stream.start


### PR DESCRIPTION
I added a benchmark for streaming psych as well as updated the use of benchmark so we don't need `puts`.

:-D
