### PR TITLE
I needed to be able to set the Accept request header for couchdb 1.2 so that chunked encoding is not returned.

### DIFF
--- a/lib/yajl/http_stream.rb
+++ b/lib/yajl/http_stream.rb
@@ -90,21 +90,21 @@ module Yajl
           uri = URI.parse(uri)
         end
 
-        user_agent = opts.has_key?('User-Agent') ? opts.delete(['User-Agent']) : "Yajl::HttpStream #{Yajl::VERSION}"
+        user_agent = opts.delete('User-Agent') || "Yajl::HttpStream #{Yajl::VERSION}"
         if method == "POST" || method == "PUT"
-          content_type = opts.has_key?('Content-Type') ? opts.delete(['Content-Type']) : "application/x-www-form-urlencoded"
+          content_type = opts.delete('Content-Type') || "application/x-www-form-urlencoded"
           body = opts.delete(:body)
           if body.is_a?(Hash)
             body = body.keys.collect {|param| "#{URI.escape(param.to_s)}=#{URI.escape(body[param].to_s)}"}.join('&')
           end
         end
 
-        socket = opts.has_key?(:socket) ? opts.delete(:socket) : TCPSocket.new(uri.host, uri.port)
+        socket = opts.delete(:socket) || TCPSocket.new(uri.host, uri.port)
         request = "#{method} #{uri.path}#{uri.query ? "?"+uri.query : nil} HTTP/1.1\r\n"
         request << "Host: #{uri.host}\r\n"
         request << "Authorization: Basic #{[uri.userinfo].pack('m').strip!}\r\n" unless uri.userinfo.nil?
         request << "User-Agent: #{user_agent}\r\n"
-        request << "Accept: */*\r\n"
+        request << "Accept: " << (opts.delete('Accept') || "*/*") << "\r\n"
         if method == "POST" || method == "PUT"
           request << "Content-Length: #{body.length}\r\n"
           request << "Content-Type: #{content_type}\r\n"


### PR DESCRIPTION
No need to call has_key? before delete on opts hash. Fix request header options. Allow modification of Accept in request header. 
