### PR TITLE
Declare and define the same Ruby extension initializer function in C

### DIFF
--- a/ext/yajl/yajl_ext.h
+++ b/ext/yajl/yajl_ext.h
@@ -132,4 +132,4 @@ static VALUE rb_yajl_json_ext_false_to_json(int argc, VALUE * argv, VALUE self);
 static VALUE rb_yajl_json_ext_nil_to_json(int argc, VALUE * argv, VALUE self);
 static VALUE rb_yajl_encoder_enable_json_gem_ext(VALUE klass);
 
-void Init_yajl_ext();
+void Init_yajl();


### PR DESCRIPTION
Currently, `yajl_ext.h` declares `void Init_yajl_ext();` but `yajl_ext.c` defines `void Init_yajl()` as the Ruby extension initializer.

This commit just brings the function name in the declaration in sync with the definition.
