### PR TITLE
Inconsistent behavior with HttpStream requests on class vs. instance

### DIFF
--- a/lib/yajl/http_stream.rb
+++ b/lib/yajl/http_stream.rb
@@ -190,6 +190,8 @@ module Yajl
   private
     # Initialize socket and add it to the opts
     def initialize_socket(uri, opts = {})
+      return if opts[:socket]
+
       @socket = TCPSocket.new(uri.host, uri.port)
       opts.merge!({:socket => @socket})
       @intentional_termination = false

--- a/spec/http/http_stream_options_spec.rb
+++ b/spec/http/http_stream_options_spec.rb
@@ -1,0 +1,28 @@
+# encoding: UTF-8
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
+require 'yajl/http_stream'
+require 'socket'
+
+describe "Passing options to HttpStream instance methods" do
+  before(:all) do
+    @stream = Yajl::HttpStream.new
+  end
+
+  it "should not create a new socket it one is provided" do
+    TCPSocket.should_not_receive(:new)
+    options = {:socket => :my_provided_socket}
+
+    @stream.send(:initialize_socket, URI.parse("http://google.com"), options)
+
+    options[:socket].should == :my_provided_socket
+  end
+
+  it "should create a new socket if one is not provided" do
+    TCPSocket.should_receive(:new).with("google.com", 80).and_return( :tcp_socket )
+    options = {}
+
+    @stream.send(:initialize_socket, URI.parse("http://google.com"), options)
+
+    options[:socket].should == :tcp_socket
+  end
+end


### PR DESCRIPTION
If you pass a socket in to the class level methods (get, put, delete, etc) the socket is used.  If you instantiate
the class, and pass in a socket, it is ignore.  This seemed wrong, and it stuck me for a good hour trying to troubleshoot.  

Here's a fix, with tests, even.  There didn't seem to be a good place to add the tests onto, so I made a new spec for them.
