### PR TITLE
Fix syntax errors for code samples in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -133,7 +133,7 @@ Since yajl-ruby does everything using streams, you simply need to pass the objec
 
 This allows you to encode JSON as a stream, writing directly to a socket
 
- socket = TCPSocket.new(192.168.1.101, 9000)
+ socket = TCPSocket.new('192.168.1.101', 9000)
  hash = {:foo => 12425125, :bar => "some string", ... }
  encoder = Yajl::Encoder.new
  Yajl::Encoder.encode(hash, socket)
@@ -141,14 +141,14 @@ This allows you to encode JSON as a stream, writing directly to a socket
 Or what if you wanted to compress the stream over the wire?
 
  require 'yajl/gzip'
- socket = TCPSocket.new(192.168.1.101, 9000)
+ socket = TCPSocket.new('192.168.1.101', 9000)
  hash = {:foo => 12425125, :bar => "some string", ... }
  Yajl::Gzip::StreamWriter.encode(hash, socket)
 
 Or what about encoding multiple objects to JSON over the same stream?
 This example will encode and send 50 JSON objects over the same stream, continuously.
 
- socket = TCPSocket.new(192.168.1.101, 9000)
+ socket = TCPSocket.new('192.168.1.101', 9000)
  encoder = Yajl::Encoder.new
  50.times do
    hash = {:current_time => Time.now.to_f, :foo => 12425125}


### PR DESCRIPTION
Hi Brian, I noticed there are missing string quotes in README. Here is the patch fixing them.

Thanks
