### PR TITLE
Fail noisily on unfinished JSON prefixes...

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -474,6 +474,16 @@ static VALUE rb_yajl_parser_parse(int argc, VALUE * argv, VALUE self) {
         return Qnil;
     }
 
+    // Because we've overridden the yajl_parse_complete state of the parser to allow
+    // us to parse multiple objects out of one stream; we can't use it to determine
+    // whether we've parsed a single object. Instead we'll check whether we've successfully
+    // parsed a single token.
+    if (!RARRAY_LEN(wrapper->builderStack) ||
+            wrapper->nestedHashLevel ||
+            wrapper->nestedArrayLevel) {
+        rb_raise(cParseError, "unexpected end of JSON string");
+    }
+
     return rb_ary_pop(wrapper->builderStack);
 }
 

--- a/spec/parsing/one_off_spec.rb
+++ b/spec/parsing/one_off_spec.rb
@@ -56,6 +56,32 @@ describe "One-off JSON examples" do
     output.should == {"key" => 1234}
   end
 
+  %w(
+    {"hi":
+    "worl
+    1.
+    tru
+    nu
+    [[[[[f
+    ["hey","babe"
+    [{"wtf...
+  ).each do |example|
+    it "should not parse #{example.inspect}" do
+      lambda {
+        Yajl::Parser.parse(example)
+      }.should raise_error "unexpected end of JSON string"
+    end
+  end
+
+  it "should not parse tails after incomplete heads" do
+      lambda {
+        Yajl::Parser.parse('{"hi":')
+      }.should raise_error
+      lambda {
+        Yajl::Parser.parse('"hi"}')
+      }.should raise_error
+  end
+
   it "should parse numbers greater than 2,147,483,648" do
     Yajl::Parser.parse("{\"id\": 2147483649}").should eql({"id" => 2147483649})
     Yajl::Parser.parse("{\"id\": 5687389800}").should eql({"id" => 5687389800})


### PR DESCRIPTION
Fixes https://github.com/brianmario/yajl-ruby/issues/58.

Based on our discussion on IRC, I guess you're not too interested in further patches to the yajl-1-based series, though I consider this a pretty major bug.
