### PR TITLE
Correctly symbolize multibyte characters.

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -287,8 +287,9 @@ static int yajl_found_hash_key(void * ctx, const unsigned char * stringVal, unsi
         memcpy(buf, stringVal, stringLen);
         buf[stringLen] = 0;
         VALUE stringEncoded = rb_str_new2(buf);
-        int enc = rb_enc_find_index("UTF-8");
-        rb_enc_associate_index(stringEncoded, enc);
+#ifdef HAVE_RUBY_ENCODING_H
+        rb_enc_associate(stringEncoded, rb_utf8_encoding());
+#endif
 
         yajl_set_static_value(ctx, ID2SYM(rb_to_id(stringEncoded)));
     } else {

--- a/spec/parsing/one_off_spec.rb
+++ b/spec/parsing/one_off_spec.rb
@@ -45,7 +45,7 @@ describe "One-off JSON examples" do
   end
 
   it "should parse using it's class method, from a utf-8 string with multibyte characters, with symbolized keys" do
-    Yajl::Parser.parse('{"日本語": 1234}', :symbolize_keys => true).should == {:日本語 => 1234}
+    Yajl::Parser.parse('{"日本語": 1234}', :symbolize_keys => true).should == {:"日本語" => 1234}
   end
 
   it "should parse using it's class method, from a string" do


### PR DESCRIPTION
Symbolizing multibyte characters will fail because Ruby assumes ASCII-8BIT encoding. This patch fixes the bug. Tested on 1.9.2, may not work on 1.8.
