### PR TITLE
Partial streaming

### DIFF
--- a/ext/yajl/yajl_ext.h
+++ b/ext/yajl/yajl_ext.h
@@ -30,6 +30,7 @@
 #define RSTRING_NOT_MODIFIED
 
 #include <ruby.h>
+VALUE rb_ary_last(int argc, VALUE *argv, VALUE ary);
 
 #ifdef HAVE_RUBY_ENCODING_H
 #include <ruby/encoding.h>
@@ -90,14 +91,24 @@ static yajl_callbacks callbacks = {
     yajl_found_end_array
 };
 
+typedef enum {
+   YPE_FOUND_HASH_KEY,
+   YPE_FOUND_END_HASH,
+   YPE_FOUND_END_ARRAY
+} yajl_parser_event;
+
 typedef struct {
     VALUE builderStack;
     VALUE parse_complete_callback;
+    VALUE hash_key_found_callback;
+    VALUE end_hash_found_callback;
+    VALUE end_array_found_callback;
     int nestedArrayLevel;
     int nestedHashLevel;
     int objectsFound;
     int symbolizeKeys;
     yajl_handle parser;
+    yajl_parser_event event;
 } yajl_parser_wrapper;
 
 typedef struct {

--- a/spec/parsing/partial_streaming_spec.rb
+++ b/spec/parsing/partial_streaming_spec.rb
@@ -1,0 +1,34 @@
+# encoding: UTF-8
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
+
+describe "Partial parser" do
+  before(:each) do
+    @parser = Yajl::Parser.new
+  end
+
+  it "should stream objects as soon as they are ready" do
+    toys = []
+    toy_ready = lambda do |item, level|
+      toys.push(item["id"]) if level == 2
+    end
+    key_scanner = lambda do |key, level|
+      if level == 1 && key == "rows"
+        @parser.on_hash_key = nil
+        @parser.on_hash_end = toy_ready
+      end
+    end
+    @parser.on_hash_key = key_scanner
+
+    @parser << '{'
+    @parser << '  "total_rows": 4,'
+    @parser << '  "rows": ['
+    @parser << '    {"id": "buzz" },'
+    @parser << '    {"id": "rex" },'
+    @parser << '    {"id": "bo" },'
+    @parser << '    {"id": "hamm" }'
+    @parser << '  ]'
+    @parser << '}'
+
+    toys.should eql(%w(buzz rex bo hamm))
+  end
+end


### PR DESCRIPTION
Hi Brian

It could be useful when we have server streming data as one big object. For example CouchDB returns results in a such way. So to consistently iterate over billions items within on snapshot client should be able to yield object as soon as they ready.

Thank you.
