### PR TITLE
Change extension path for lib directory to yajl/yajl

### DIFF
--- a/ext/yajl/extconf.rb
+++ b/ext/yajl/extconf.rb
@@ -5,4 +5,4 @@ require 'rbconfig'
 $CFLAGS << ' -Wall -funroll-loops'
 $CFLAGS << ' -Wextra -O0 -ggdb3' if ENV['DEBUG']
 
-create_makefile("yajl")
+create_makefile("yajl/yajl")

--- a/yajl-ruby.gemspec
+++ b/yajl-ruby.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   ]
   s.files = `git ls-files`.split("\n")
   s.homepage = %q{http://github.com/brianmario/yajl-ruby}
-  s.require_paths = ["lib", "ext"]
+  s.require_paths = ["lib"]
   s.rubygems_version = %q{1.4.2}
   s.summary = %q{Ruby C bindings to the excellent Yajl JSON stream-based parser library.}
   s.test_files = `git ls-files spec examples`.split("\n")


### PR DESCRIPTION
I came across issue #78  some days ago while trying to compile the yajl-ruby gem with the gem-compile rubygem command plugin. The plugin only included the extension placed on the lib directory and so requiring yajl after installing the compiled gem failed.

While looking into the problem I noticed that the argument for the create_makefile in yajl-ruby's extconf.rb is "yajl" instead of "yajl/yajl", and thus it places the extension in lib/yajl.so instead of the expected place, lib/yajl/yajl.so.

I've modified the extconf.rb file to fix this and removed the ext path from the required paths on the gemspec. I've check that the gem can be installed and required, and that the specs pass. I have not tested it with package managers such as rpg as described in issue #78 though.

First pull request ever, I hope this is of use.
