### PR TITLE
HACK: do not expose libyajl API

### DIFF
--- a/ext/yajl/api/yajl_common.h
+++ b/ext/yajl/api/yajl_common.h
@@ -50,7 +50,7 @@ extern "C" {
 #  endif
 #else
 #  if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 303
-#    define YAJL_API __attribute__ ((visibility("default")))
+#    define YAJL_API __attribute__ ((visibility("hidden")))
 #  else
 #    define YAJL_API
 #  endif

--- a/ext/yajl/api/yajl_parse.h
+++ b/ext/yajl/api/yajl_parse.h
@@ -133,7 +133,7 @@ extern "C" {
                                     void * ctx);
     
     /** allow resetting of the lexer without the need to realloc a new parser */
-    void yajl_reset_parser(yajl_handle hand);
+    YAJL_API void yajl_reset_parser(yajl_handle hand);
 
     /** free a parser handle */    
     YAJL_API void yajl_free(yajl_handle handle);

--- a/ext/yajl/yajl_alloc.h
+++ b/ext/yajl/yajl_alloc.h
@@ -45,6 +45,7 @@
 #define YA_FREE(afs, ptr) (afs)->free((afs)->ctx, (ptr))
 #define YA_REALLOC(afs, ptr, sz) (afs)->realloc((afs)->ctx, (ptr), (sz))
 
+YAJL_API
 void yajl_set_default_alloc_funcs(yajl_alloc_funcs * yaf);
 
 #endif

--- a/ext/yajl/yajl_buf.h
+++ b/ext/yajl/yajl_buf.h
@@ -50,24 +50,31 @@
 typedef struct yajl_buf_t * yajl_buf;
 
 /* allocate a new buffer */
+YAJL_API
 yajl_buf yajl_buf_alloc(yajl_alloc_funcs * alloc);
 
 /* free the buffer */
+YAJL_API
 void yajl_buf_free(yajl_buf buf);
 
 /* append a number of bytes to the buffer */
+YAJL_API
 void yajl_buf_append(yajl_buf buf, const void * data, unsigned int len);
 
 /* empty the buffer */
+YAJL_API
 void yajl_buf_clear(yajl_buf buf);
 
 /* get a pointer to the beginning of the buffer */
+YAJL_API
 const unsigned char * yajl_buf_data(yajl_buf buf);
 
 /* get the length of the buffer */
+YAJL_API
 unsigned int yajl_buf_len(yajl_buf buf);
 
 /* truncate the buffer */
+YAJL_API
 void yajl_buf_truncate(yajl_buf buf, unsigned int len);
 
 #endif

--- a/ext/yajl/yajl_encode.h
+++ b/ext/yajl/yajl_encode.h
@@ -36,16 +36,19 @@
 #include "yajl_buf.h"
 #include "api/yajl_gen.h"
 
+YAJL_API
 void yajl_string_encode2(const yajl_print_t printer,
                          void * ctx,
                          const unsigned char * str,
                          unsigned int length,
                          unsigned int htmlSafe);
 
+YAJL_API
 void yajl_string_encode(yajl_buf buf, const unsigned char * str,
                         unsigned int length,
                         unsigned int htmlSafe);
 
+YAJL_API
 void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                         unsigned int length);
 

--- a/ext/yajl/yajl_ext.h
+++ b/ext/yajl/yajl_ext.h
@@ -63,8 +63,8 @@ static ID sym_allow_comments, sym_check_utf8, sym_pretty, sym_indent, sym_termin
 
 static void yajl_check_and_fire_callback(void * ctx);
 static void yajl_set_static_value(void * ctx, VALUE val);
-void yajl_encode_part(void * wrapper, VALUE obj, VALUE io);
-void yajl_parse_chunk(const unsigned char * chunk, unsigned int len, yajl_handle parser);
+static void yajl_encode_part(void * wrapper, VALUE obj, VALUE io);
+static void yajl_parse_chunk(const unsigned char * chunk, unsigned int len, yajl_handle parser);
 
 static int yajl_found_null(void * ctx);
 static int yajl_found_boolean(void * ctx, int boolean);

--- a/ext/yajl/yajl_lex.h
+++ b/ext/yajl/yajl_lex.h
@@ -63,12 +63,16 @@ typedef enum {
 
 typedef struct yajl_lexer_t * yajl_lexer;
 
+
+YAJL_API
 yajl_lexer yajl_lex_alloc(yajl_alloc_funcs * alloc,
                           unsigned int allowComments,
                           unsigned int validateUTF8);
 
+YAJL_API
 yajl_lexer yajl_lex_realloc(yajl_lexer orig);
 
+YAJL_API
 void yajl_lex_free(yajl_lexer lexer);
 
 /**
@@ -93,11 +97,13 @@ n * error messages.
  * implications which require that the client choose a reasonable chunk
  * size to get adequate performance.
  */
+YAJL_API
 yajl_tok yajl_lex_lex(yajl_lexer lexer, const unsigned char * jsonText,
                       unsigned int jsonTextLen, unsigned int * offset,
                       const unsigned char ** outBuf, unsigned int * outLen);
 
 /** have a peek at the next token, but don't move the lexer forward */
+YAJL_API
 yajl_tok yajl_lex_peek(yajl_lexer lexer, const unsigned char * jsonText,
                        unsigned int jsonTextLen, unsigned int offset);
 
@@ -116,20 +122,25 @@ typedef enum {
     yajl_lex_unallowed_comment
 } yajl_lex_error;
 
+YAJL_API
 const char * yajl_lex_error_to_string(yajl_lex_error error);
 
 /** allows access to more specific information about the lexical
  *  error when yajl_lex_lex returns yajl_tok_error. */
+YAJL_API
 yajl_lex_error yajl_lex_get_error(yajl_lexer lexer);
 
 /** get the current offset into the most recently lexed json string. */
+YAJL_API
 unsigned int yajl_lex_current_offset(yajl_lexer lexer);
 
 /** get the number of lines lexed by this lexer instance */
+YAJL_API
 unsigned int yajl_lex_current_line(yajl_lexer lexer);
 
 /** get the number of chars lexed by this lexer instance since the last
  *  \n or \r */
+YAJL_API
 unsigned int yajl_lex_current_char(yajl_lexer lexer);
 
 #endif

--- a/ext/yajl/yajl_parser.h
+++ b/ext/yajl/yajl_parser.h
@@ -70,10 +70,12 @@ struct yajl_handle_t {
     yajl_alloc_funcs alloc;
 };
 
+YAJL_API
 yajl_status
 yajl_do_parse(yajl_handle handle, const unsigned char * jsonText,
               unsigned int jsonTextLen);
 
+YAJL_API
 unsigned char *
 yajl_render_error_string(yajl_handle hand, const unsigned char * jsonText,
                          unsigned int jsonTextLen, int verbose);


### PR DESCRIPTION
This patch hides libyajl API and allow other gems that use the same API calls load after `yajl-ruby`.  This patch is related to issue #92
