### PR TITLE
DATA_PTR isn't available on MagLev

### DIFF
--- a/ext/yajl/yajl_ext.h
+++ b/ext/yajl/yajl_ext.h
@@ -58,8 +58,8 @@ static ID intern_io_read, intern_call, intern_keys, intern_to_s,
             intern_to_json, intern_has_key, intern_to_sym, intern_as_json;
 static ID sym_allow_comments, sym_check_utf8, sym_pretty, sym_indent, sym_terminator, sym_symbolize_keys, sym_html_safe;
 
-#define GetParser(obj, sval) (sval = (yajl_parser_wrapper*)DATA_PTR(obj));
-#define GetEncoder(obj, sval) (sval = (yajl_encoder_wrapper*)DATA_PTR(obj));
+#define GetParser(obj, sval) Data_Get_Struct(obj, yajl_parser_wrapper, sval);
+#define GetEncoder(obj, sval) Data_Get_Struct(obj, yajl_encoder_wrapper, sval);
 
 static void yajl_check_and_fire_callback(void * ctx);
 static void yajl_set_static_value(void * ctx, VALUE val);


### PR DESCRIPTION
`DATA_PTR` is only used to do what `Data_Get_Struct` does, which is supported in MagLev.
