### PR TITLE
Testing with ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rvm:
   - 1.9.3
   - rbx
   - ree
+  - ruby-head

--- a/ext/yajl/yajl_ext.h
+++ b/ext/yajl/yajl_ext.h
@@ -24,9 +24,9 @@
 #include "api/yajl_parse.h"
 #include "api/yajl_gen.h"
 
-// tell rbx not to use it's caching compat layer
-// by doing this we're making a promize to RBX that
-// we'll never modify the pointers we get back from RSTRING_PTR
+/* tell rbx not to use it's caching compat layer
+   by doing this we're making a promize to RBX that
+   we'll never modify the pointers we get back from RSTRING_PTR */
 #define RSTRING_NOT_MODIFIED
 
 #include <ruby.h>


### PR DESCRIPTION
ruby 2.0dev forces C90 on it's C extensions, so avoid // comments
