### PR TITLE
Fix segmentation fault when encoding deeply-nested arrays or hashes

### DIFF
--- a/lib/yajl.rb
+++ b/lib/yajl.rb
@@ -12,6 +12,7 @@ require 'yajl/yajl'
 #
 # Ruby bindings to the excellent Yajl (Yet Another JSON Parser) ANSI C library.
 module Yajl
+
   # For compatibility, has the same signature of Yajl::Parser.parse
   def self.load(str_or_io, options={}, read_bufsize=nil, &block)
     Parser.parse(str_or_io, options, read_bufsize, &block)

--- a/spec/encoding/encoding_spec.rb
+++ b/spec/encoding/encoding_spec.rb
@@ -294,4 +294,22 @@ describe "Yajl JSON encoder" do
       Yajl::Encoder.encode(TheMindKillerDuce.new)
     }.should raise_error(TypeError)
   end
+
+  it "should raise an exception for deeply nested arrays" do
+    root = []
+    a = root
+    (Yajl::MAX_DEPTH + 1).times { |_| a << []; a = a[0] }
+    lambda {
+      Yajl::Encoder.encode(root)
+    }.should raise_error(Yajl::EncodeError)
+  end
+
+  it "should raise an exception for deeply nested hashes" do
+    root = {}
+    a = root
+    (Yajl::MAX_DEPTH + 1).times { |_| a["a"] = {}; a = a["a"] }
+    lambda {
+      Yajl::Encoder.encode(root)
+    }.should raise_error(Yajl::EncodeError)
+  end
 end


### PR DESCRIPTION
This fixes #125 by ensuring that we always check the return value from
yajl_gen_\* functions, and raise an exception when these functions return
anything but yajl_gen_status_ok.

In particular, we now will raise a Yajl::EncodeError when we attempt to encode
a deeply nested array or hash (with a depth > YAJL_MAX_DEPTH).

I didn't include any change to `YAJL_MAX_DEPTH` here, since I didn't want
to muddle the two issues (handling the error stats vs. bumping max depth),
but I'd be very in support of bumping it to 256.
