### PR TITLE
Rename gem from yajl-ruby to yajl

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can read more info at the project's website http://lloyd.github.com/yajl or 
 Go ahead and install it as usual:
 
 ```
-gem install yajl-ruby
+gem install yajl
 ```
 
 Or use your Gemfile:

--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -1,7 +1,7 @@
 require 'rake/extensiontask'
 
 def gemspec
-  @clean_gemspec ||= eval(File.read(File.expand_path('../../yajl-ruby.gemspec', __FILE__)))
+  @clean_gemspec ||= eval(File.read(File.expand_path('../../yajl.gemspec', __FILE__)))
 end
 
 Rake::ExtensionTask.new('yajl', gemspec) do |ext|

--- a/yajl.gemspec
+++ b/yajl.gemspec
@@ -1,7 +1,7 @@
 require './lib/yajl/version'
 
 Gem::Specification.new do |s|
-  s.name = %q{yajl-ruby}
+  s.name = %q{yajl}
   s.version = Yajl::VERSION
   s.license = "MIT"
   s.authors = ["Brian Lopez", "Lloyd Hilaiel"]


### PR DESCRIPTION
It makes sense for this repository to be named `yajl-ruby`, to avoid ambiguity with other wrapper libraries (not to mention YAJL itself) but the gem name need not include `-ruby`, since the `rubygems` package manager is tightly coupled to the Ruby language. Just as the [`sqlite3-ruby` gem was renamed to `sqlite`](https://github.com/sparklemotion/sqlite3-ruby/commit/59855b543f2506829403c1d91f9c93c84298ade0), this package’s name should just be `yajl`.

This also increases consistency between the library’s name and the way it is required.

``` ruby
require 'yajl'
```
