### PR TITLE
Add Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.1.1
+  - 2.1.2
   - ree
   - ruby-head
   - rbx-18mode


### PR DESCRIPTION
Would be great to know Ruby 2.1.2 is supported.
