### PR TITLE
Update rspec development dependency to ~> 3.0

### DIFF
--- a/spec/http/http_error_spec.rb
+++ b/spec/http/http_error_spec.rb
@@ -9,11 +9,11 @@ require 'yajl/deflate'
 require 'yajl/http_stream'
 
 describe "Yajl HTTP error" do
-  before(:all) do
+  before do
     @uri = 'file://' + File.expand_path(File.dirname(__FILE__) + "/fixtures/http/http.error.dump")
     @request = File.new(File.expand_path(File.dirname(__FILE__) + "/fixtures/http.error.dump"), 'r')
-    TCPSocket.should_receive(:new).and_return(@request)
-    @request.should_receive(:write)
+    allow(TCPSocket).to receive(:new).and_return(@request)
+    allow(@request).to receive(:write)
     begin
       Yajl::HttpStream.get(@uri)
     rescue Yajl::HttpStream::HttpError => e

--- a/yajl-ruby.gemspec
+++ b/yajl-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   # tests
   s.add_development_dependency 'rake-compiler', '>= 0.7.5'
-  s.add_development_dependency 'rspec', '~> 2.99'
+  s.add_development_dependency 'rspec', '~> 3.0'
   # benchmarks
   s.add_development_dependency 'activesupport', '~> 3.1.2'
   s.add_development_dependency 'json'


### PR DESCRIPTION
Following https://github.com/brianmario/yajl-ruby/pull/141, update to RSpec 3, now that it has been released.
