### PR TITLE
Specified flags are not compatible with Solaris Studio C compiler.

### DIFF
--- a/ext/yajl/extconf.rb
+++ b/ext/yajl/extconf.rb
@@ -1,7 +1,11 @@
 require 'mkmf'
 require 'rbconfig'
 
-$CFLAGS << ' -Wall -funroll-loops'
-$CFLAGS << ' -Werror-implicit-function-declaration -Wextra -O0 -ggdb3' if ENV['DEBUG']
+if RbConfig::CONFIG['host_os'] =~ /solaris(!?2\.1[0-2])/
+  if RbConfig::CONFIG['GCC'] != ""
+    $CFLAGS << ' -Wall -funroll-loops'
+    $CFLAGS << ' -Werror-implicit-function-declaration -Wextra -O0 -ggdb3' if ENV['DEBUG']
+  end
+end
 
 create_makefile('yajl/yajl')


### PR DESCRIPTION
When using the Solaris Studio C compiler, the specified flags generate errors.  This may affect other compilers, but this is at least a starting point.
