### PR TITLE
Fixed crash with sigabort on invalid surrogate sequence

### DIFF
--- a/ext/yajl/yajl_lex.h
+++ b/ext/yajl/yajl_lex.h
@@ -119,7 +119,8 @@ typedef enum {
     yajl_lex_missing_integer_after_decimal,
     yajl_lex_missing_integer_after_exponent,
     yajl_lex_missing_integer_after_minus,
-    yajl_lex_unallowed_comment
+    yajl_lex_unallowed_comment,
+    yajl_lex_string_invalid_surrogate,
 } yajl_lex_error;
 
 YAJL_API

--- a/lib/yajl/version.rb
+++ b/lib/yajl/version.rb
@@ -1,3 +1,3 @@
 module Yajl
-  VERSION = '1.2.2'
+  VERSION = '1.2.1'
 end

--- a/lib/yajl/version.rb
+++ b/lib/yajl/version.rb
@@ -1,3 +1,3 @@
 module Yajl
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end

--- a/spec/parsing/one_off_spec.rb
+++ b/spec/parsing/one_off_spec.rb
@@ -76,7 +76,6 @@ describe "One-off JSON examples" do
   end
 
   it "should accept correct surrogate pairs" do
-    Encoding.default_internal = Encoding.find('utf-8')
     expect {
       expect(Yajl::Parser.parse('["\\ud800\\udf02"]')).to eql(["𐌂"])
     }.not_to raise_error

--- a/spec/parsing/one_off_spec.rb
+++ b/spec/parsing/one_off_spec.rb
@@ -66,6 +66,22 @@ describe "One-off JSON examples" do
     expect(Yajl::Parser.parse("{\"id\": 1046289770033519442869495707521600000000}")).to eql({"id" => 1046289770033519442869495707521600000000})
   end
 
+  it "should not crash on JSON with broken surrogate pair, but should raise exception instead" do
+    expect {
+      Yajl::Parser.parse('["\\ud800\\\\a"]')
+    }.to raise_error(Yajl::ParseError)
+    expect {
+      Yajl::Parser.parse('["\\ud800\\\\u"]')
+    }.to raise_error(Yajl::ParseError)
+  end
+
+  it "should accept correct surrogate pairs" do
+    Encoding.default_internal = Encoding.find('utf-8')
+    expect {
+      expect(Yajl::Parser.parse('["\\ud800\\udf02"]')).to eql(["𐌂"])
+    }.not_to raise_error
+  end
+
   if RUBY_VERSION =~ /^1.9/
     it "should encode non-ascii symbols in utf-8" do
       parsed = Yajl::Parser.parse('{"曦": 1234}', :symbolize_keys => true)


### PR DESCRIPTION
Example code to reproduce, before this fix is applied:

```
1.9.3-p484 :002 > Yajl::Parser.parse('["\\ud800\\\\a"]')
irb: yajl_encode.c:192: yajl_string_decode: Assertion `"this should never happen" == ((void *)0)' failed.
Aborted

1.9.3-p484 :001 > require 'yajl'
 => true 
1.9.3-p484 :002 >       Yajl::Parser.parse('["\\ud800\\\\u"]')
irb: yajl_encode.c:108: hexToDigit: Assertion `!(c & 0xF0)' failed.
Aborted
```

If a specifically crafted JSON is sent to a server, which uses yajl-ruby, it can cause the server to crash, thus potentially creating a DOS attack vector.
