### PR TITLE
Don't use StringIO in benchmarks

### DIFF
--- a/benchmark/encode.rb
+++ b/benchmark/encode.rb
@@ -4,7 +4,6 @@ $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 require 'rubygems'
 require 'benchmark'
 require 'yajl'
-require 'stringio'
 begin
   require 'json'
 rescue LoadError
@@ -29,7 +28,7 @@ Benchmark.bmbm { |x|
 
   x.report("Yajl::Encoder#encode (to an IO)") {
     times.times {
-      io_encoder.encode(hash, StringIO.new)
+      io_encoder.encode(hash, File.open(File::NULL, 'w'))
     }
   }
   x.report("Yajl::Encoder#encode (to a String)") {
@@ -53,7 +52,7 @@ Benchmark.bmbm { |x|
     if defined?(Psych::JSON::Stream)
       x.report("Psych::JSON::Stream") {
         times.times {
-          io = StringIO.new
+          io = File.open(File::NULL, 'w')
           stream = Psych::JSON::Stream.new io
           stream.start
           stream.push hash

--- a/benchmark/encode_json_and_marshal.rb
+++ b/benchmark/encode_json_and_marshal.rb
@@ -4,7 +4,6 @@ $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 require 'rubygems'
 require 'benchmark'
 require 'yajl'
-require 'stringio'
 begin
   require 'json'
 rescue LoadError
@@ -22,7 +21,7 @@ Benchmark.bmbm { |x|
   x.report {
     puts "Yajl::Encoder#encode"
     times.times {
-      encoder.encode(hash, StringIO.new)
+      encoder.encode(hash, File.open(File::NULL, 'w'))
     }
   }
   if defined?(JSON)

--- a/benchmark/encode_json_and_yaml.rb
+++ b/benchmark/encode_json_and_yaml.rb
@@ -23,7 +23,7 @@ Benchmark.bmbm { |x|
   x.report {
     puts "Yajl::Encoder#encode"
     times.times {
-      encoder.encode(hash, StringIO.new)
+      encoder.encode(hash, File.open(File::NULL, 'w'))
     }
   }
   if defined?(JSON)
@@ -47,7 +47,7 @@ Benchmark.bmbm { |x|
   x.report {
     puts "YAML.dump"
     times.times {
-      YAML.dump(data, StringIO.new)
+      YAML.dump(data, File.open(File::NULL, 'w'))
     }
   }
 }


### PR DESCRIPTION
StringIO seems to be absurdly slow, on the order of ten times slower
than writing to a real IO (e.g. a file). Writing the output to the
null device (/dev/null on Linux, NUL on Windows, etc.) should be much more
reasonable for performance comparison.

Results from `benchmark/encode.rb` on my machine, using `StringIO.new`
and `File.open(File::NULL, 'w')`:

|                                      |  StringIO | Null device |
| ------------------------------------ | --------- | ----------- |
| Yajl::Encoder#encode (to an IO)      |  3.085176 |    0.683039 |
| Yajl::Encoder#encode (to a String)   |  0.526030 |    0.544032 |
| JSON.generate                        |  1.380079 |    1.432082 |
| Psych.to_json                        | 10.271588 |   10.016573 |
| Psych::JSON::Stream                  |  9.238529 |    4.949283 |
| ActiveSupport::JSON.encode           | 10.817619 |   10.233585 |