### PR TITLE
Performance improvements when encoding very large hashes with symbol keys

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -199,6 +199,11 @@ void yajl_encode_part(void * wrapper, VALUE obj, VALUE io) {
             CHECK_STATUS(yajl_gen_bool(w->encoder, 0));
             break;
         case T_FIXNUM:
+            str = rb_fix2str(obj, 10);
+            cptr = RSTRING_PTR(str);
+            len = RSTRING_LEN(str);
+            CHECK_STATUS(yajl_gen_number(w->encoder, cptr, len));
+            break;
         case T_FLOAT:
         case T_BIGNUM:
             str = rb_funcall(obj, intern_to_s, 0);

--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -167,7 +167,12 @@ void yajl_encode_part(void * wrapper, VALUE obj, VALUE io) {
             keys = rb_funcall(obj, intern_keys, 0);
             for(idx=0; idx<RARRAY_LEN(keys); idx++) {
                 entry = rb_ary_entry(keys, idx);
-                keyStr = rb_funcall(entry, intern_to_s, 0); /* key must be a string */
+                /* key must be encoded as a string */
+                if(RB_TYPE_P(entry, T_STRING) || RB_TYPE_P(entry, T_SYMBOL)) {
+                    keyStr = entry;
+                } else {
+                    keyStr = rb_funcall(entry, intern_to_s, 0);
+                }
                 /* the key */
                 yajl_encode_part(w, keyStr, io);
                 /* the value */

--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -209,6 +209,12 @@ void yajl_encode_part(void * wrapper, VALUE obj, VALUE io) {
             len = RSTRING_LEN(obj);
             CHECK_STATUS(yajl_gen_string(w->encoder, (const unsigned char *)cptr, len));
             break;
+        case T_SYMBOL:
+            str = rb_id2str(SYM2ID(obj));
+            cptr = RSTRING_PTR(str);
+            len = RSTRING_LEN(str);
+            CHECK_STATUS(yajl_gen_string(w->encoder, (const unsigned char *)cptr, len));
+            break;
         default:
             if (rb_respond_to(obj, intern_to_json)) {
                 str = rb_funcall(obj, intern_to_json, 0);


### PR DESCRIPTION
I'm currently working on a project which involves processing a huge hash (a couple gigabytes in memory) and occasionally dumping it as JSON (about 1 GB of it). (The project is [MatmaRex/commons-media-views](https://github.com/MatmaRex/commons-media-views), please don't ask why I didn't do something saner, this seemed like a good idea at the time and now it's an interesting mental exercise.) I switched from built-in JSON parser/encode to YAJL for streamed encoding, but the performance seemed not quite as good as I expected. I did some digging and here are the results.

This set of patches should improve encoding performance across the board, but particularly when encoding hashes, and particularly when they have symbolic keys, and especially when they're really large. It looks like most of it is thanks to reduced number of object allocations, and thus fewer GC pauses while encoding. The only potential drawback is that some monkey-patched methods on builtin classes that previously were respected will no longer be. I don't think that's something you're aiming to support.

Testing with this large file: https://dl.dropboxusercontent.com/u/10983006/tmp/big.json (~110 MB) parsed with `Yajl::Parser.new(symbolize_keys: true)`, I get a 2x performance improvement when encoding the parsed data back into JSON.