### PR TITLE
Add a string cache to take advantage of CoW strings

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -355,7 +355,7 @@ static int yajl_found_hash_key(void * ctx, const unsigned char * stringVal, unsi
         keyStr = rb_str_intern(str);
 #endif
     } else {
-        keyStr = rb_str_new((const char *)stringVal, stringLen);
+        keyStr = find_or_make_string(wrapper->strings, stringVal, stringLen);
 #ifdef HAVE_RUBY_ENCODING_H
         rb_enc_associate(keyStr, utf8Encoding);
         if (default_internal_enc) {

--- a/ext/yajl/yajl_ext.h
+++ b/ext/yajl/yajl_ext.h
@@ -30,6 +30,7 @@
 #define RSTRING_NOT_MODIFIED
 
 #include <ruby.h>
+#include <ruby/st.h>
 
 #ifdef HAVE_RUBY_ENCODING_H
 #include <ruby/encoding.h>
@@ -98,6 +99,7 @@ typedef struct {
     int objectsFound;
     int symbolizeKeys;
     yajl_handle parser;
+    st_table * strings;
 } yajl_parser_wrapper;
 
 typedef struct {

--- a/ext/yajl/yajl_ext.h
+++ b/ext/yajl/yajl_ext.h
@@ -100,6 +100,7 @@ typedef struct {
     int symbolizeKeys;
     yajl_handle parser;
     st_table * strings;
+    st_table * keycache;
 } yajl_parser_wrapper;
 
 typedef struct {


### PR DESCRIPTION
This PR contains 2 caches.  The first cache is for CoW savings with duplicated values, and the second cache is for CoW *and* object allocation savings in keys.  We need to get some statistics on the JSON we're parsing before we can say that either of these will help us.  The "value CoW cache" is probably the most dubious because I suspect that most values are unique.  My hunch is that we'll see much more repetition in JSON keys than in JSON values, so the second cache may have more value.

IOW this patch only helps if you have JSON docs that repeat data, and I suspect that if any data is repeated, it will be in the JSON keys.