### PR TITLE
Spec: Captured ruby script output passed via bundler

### DIFF
--- a/spec/parsing/large_number_spec.rb
+++ b/spec/parsing/large_number_spec.rb
@@ -39,7 +39,7 @@ describe 'Parsing very long text' do
     end
 
     it 'runs successfully' do
-      out, err, status = capture('ruby', script)
+      out, err, status = capture('bundle exec ruby', script)
       expect([err, status.exitstatus]).to eq(['', 0])
     end
   end


### PR DESCRIPTION
This PR makes the spec for numbers, which calls out to a child process, wrap that ruby call in a "bundle exec".

This made the test suite run on my machine.