### PR TITLE
Backport #165 for v1.2.x: Support removal of Fixnum class in Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - ruby-head
   - rbx-18mode
   - rbx-19mode
+before_install: gem install bundler --no-document
 matrix:
   allow_failures:
     - rvm: rbx

--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -878,7 +878,11 @@ static VALUE rb_yajl_json_ext_nil_to_json(int argc, VALUE * argv, VALUE self) {
 static VALUE rb_yajl_encoder_enable_json_gem_ext(VALUE klass) {
     rb_define_method(rb_cHash, "to_json", rb_yajl_json_ext_hash_to_json, -1);
     rb_define_method(rb_cArray, "to_json", rb_yajl_json_ext_array_to_json, -1);
+#ifdef RUBY_INTEGER_UNIFICATION
+    rb_define_method(rb_cInteger, "to_json", rb_yajl_json_ext_fixnum_to_json, -1);
+#else
     rb_define_method(rb_cFixnum, "to_json", rb_yajl_json_ext_fixnum_to_json, -1);
+#endif
     rb_define_method(rb_cFloat, "to_json", rb_yajl_json_ext_float_to_json, -1);
     rb_define_method(rb_cString, "to_json", rb_yajl_json_ext_string_to_json, -1);
     rb_define_method(rb_cTrueClass, "to_json", rb_yajl_json_ext_true_to_json, -1);


### PR DESCRIPTION
This backports #165 for the v1.2.x series, which is explicitly required by pygments.rb 0.6.x (using `~> 1.2.0` in the gemspec). This will allow users of pygments.rb 0.6 to continue using it and still allow them to upgrade to Ruby 2.4. The noted incompatibility with pygments.rb 1.x is the use of symlinks in the underlying (and vendored) Pygments (python) library, which breaks compatibility with Windows users.

Running `bundle exec rspec` passes:

```text
Finished in 0.86334 seconds
411 examples, 0 failures
```

with `ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]`.

@brianmario If you don't mind creating a branch based off the `1.2.1` tag, then this PR can target that branch and be merged & released as 1.2.2. 💗 