### PR TITLE
Fix some warnings

### DIFF
--- a/lib/yajl/bzip2.rb
+++ b/lib/yajl/bzip2.rb
@@ -6,6 +6,6 @@ begin
   require 'bzip2' unless defined?(Bzip2)
   require 'yajl/bzip2/stream_reader.rb'
   require 'yajl/bzip2/stream_writer.rb'
-rescue LoadError => e
+rescue LoadError
   raise "Unable to load the bzip2 library. Is the bzip2-ruby gem installed?"
 end

--- a/lib/yajl/http_stream.rb
+++ b/lib/yajl/http_stream.rb
@@ -4,6 +4,7 @@ require 'socket'
 require 'yajl'
 require 'yajl/version' unless defined? Yajl::VERSION
 require 'uri'
+require 'cgi'
 
 module Yajl
   # This module is for making HTTP requests to which the response bodies (and possibly requests in the near future)
@@ -101,7 +102,7 @@ module Yajl
           default_headers["Content-Type"] = opts["Content-Type"] || "application/x-www-form-urlencoded"
           body = opts.delete(:body)
           if body.is_a?(Hash)
-            body = body.keys.collect {|param| "#{URI.escape(param.to_s)}=#{URI.escape(body[param].to_s)}"}.join('&')
+            body = body.keys.collect {|param| "#{CGI.escape(param.to_s)}=#{CGI.escape(body[param].to_s)}"}.join('&')
           end
           default_headers["Content-Length"] = body.length
         end

--- a/lib/yajl/http_stream.rb
+++ b/lib/yajl/http_stream.rb
@@ -161,7 +161,7 @@ module Yajl
           if block_given?
             chunkLeft = 0
             while !socket.eof? && (line = socket.gets)
-              break if line.match /^0.*?\r\n/
+              break if line.match(/^0.*?\r\n/)
               next if line == "\r\n"
               size = line.hex
               json = socket.read(size)


### PR DESCRIPTION
This PR suppresses the following warnings.

- lib/yajl/bzip2.rb:9: warning: assigned but unused variable - e
- lib/yajl/http_stream.rb:164: warning: ambiguous first argument; put parentheses or a space even after `/' operator
- lib/yajl/http_stream.rb:104:in `block in request': warning: URI.escape is obsolete

This patch was tested with Ruby 2.4.1. Thanks.
