### PR TITLE
Fix parsing bad surrogate trailers

### DIFF
--- a/ext/yajl/yajl_encode.c
+++ b/ext/yajl/yajl_encode.c
@@ -189,7 +189,8 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                     break;
                 }
                 default:
-                    assert("this should never happen" == NULL);
+                    unescaped = "?";
+                    break;
             }
             yajl_buf_append(buf, unescaped, (unsigned int)strlen(unescaped));
             beg = ++end;

--- a/ext/yajl/yajl_encode.c
+++ b/ext/yajl/yajl_encode.c
@@ -162,8 +162,8 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                     end+=3;
                     /* check if this is a surrogate */
                     if ((codepoint & 0xFC00) == 0xD800) {
-                        end++;
-                        if (str[end] == '\\' && str[end + 1] == 'u') {
+                        if (end + 2 < len && str[end + 1] == '\\' && str[end + 2] == 'u') {
+                            end++;
                             unsigned int surrogate = 0;
                             hexToDigit(&surrogate, str + end + 2);
                             codepoint =
@@ -189,8 +189,7 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                     break;
                 }
                 default:
-                    unescaped = "?";
-                    break;
+                    assert("this should never happen" == NULL);
             }
             yajl_buf_append(buf, unescaped, (unsigned int)strlen(unescaped));
             beg = ++end;

--- a/spec/parsing/one_off_spec.rb
+++ b/spec/parsing/one_off_spec.rb
@@ -2,6 +2,12 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
 
 describe "One-off JSON examples" do
+  it "should not blow up with a bad surrogate trailer" do
+    bad_json = "{\"e\":{\"\\uD800\\\\DC00\":\"a\"}}"
+
+    Yajl::Parser.new.parse(bad_json)
+  end
+
   it "should parse 23456789012E666 and return Infinity" do
     infinity = (1.0/0)
     silence_warnings do


### PR DESCRIPTION
If a valid surrogate character escape is found and the following byte sequence isn't a valid unicode escape sequence, insert our replacement character '?' as we would any other place we saw invalid characters while unescaping.

In general, this default case from this switch should be treated as seeing an invalid character in the sequence. So we should replace it with our replacement character instead of blowing up.

This fix should be applied upstream on yajl itself as well, but I'm starting here since that's where the original issue was reported and we have a patched yajl embedded anyway.

Fixes #176