### PR TITLE
Fix potential bad read

### DIFF
--- a/ext/yajl/yajl_encode.c
+++ b/ext/yajl/yajl_encode.c
@@ -162,8 +162,8 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                     end+=3;
                     /* check if this is a surrogate */
                     if ((codepoint & 0xFC00) == 0xD800) {
-                        end++;
-                        if (str[end] == '\\' && str[end + 1] == 'u') {
+                        if (end + 2 < len && str[end + 1] == '\\' && str[end + 2] == 'u') {
+                            end++;
                             unsigned int surrogate = 0;
                             hexToDigit(&surrogate, str + end + 2);
                             codepoint =

--- a/spec/parsing/one_off_spec.rb
+++ b/spec/parsing/one_off_spec.rb
@@ -2,6 +2,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
 
 describe "One-off JSON examples" do
+  it "should not blow up with a bad surrogate trailer" do
+    # https://github.com/brianmario/yajl-ruby/issues/176
+    bad_json = "{\"e\":{\"\\uD800\\\\DC00\":\"a\"}}"
+
+    Yajl::Parser.new.parse(bad_json)
+  end
+
   it "should parse 23456789012E666 and return Infinity" do
     infinity = (1.0/0)
     silence_warnings do


### PR DESCRIPTION
When decoding a string with escape sequences sure we need to make sure we don't advance our `end` pointer until we've checked we have enough buffer left to parse, as well as have peeked ahead to see that a unicode escape is approaching.

Thanks @kivikakk for helping me track down the actual bug here! (Previous attempt [here](https://github.com/brianmario/yajl-ruby/pull/177))

This fix should be applied upstream on yajl itself as well, but I'm starting here since that's where the original issue was reported and we have a patched yajl embedded anyway.

Fixes #176