### PR TITLE
Never abort the process for code supposed to be run in non debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vendor/gems
 Gemfile.lock
 .rbx
 bin/
+ext/yajl/yajl.so

--- a/ext/yajl/yajl_encode.h
+++ b/ext/yajl/yajl_encode.h
@@ -33,6 +33,8 @@
 #ifndef __YAJL_ENCODE_H__
 #define __YAJL_ENCODE_H__
 
+#define NDEBUG FALSE
+
 #include "yajl_buf.h"
 #include "api/yajl_gen.h"
 


### PR DESCRIPTION
`assert` is used for debug purposes and should not be used for code that is intended to be used in production