### PR TITLE
Added option to do entity encoding

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -1030,8 +1030,13 @@ static VALUE rb_yajl_encoder_new(int argc, VALUE * argv, VALUE klass) {
                 actualIndent = indentString;
             }
         }
+
         if (rb_hash_aref(opts, sym_html_safe) == Qtrue) {
           htmlSafe = 1;
+        }
+
+        if (rb_hash_aref(opts, sym_entities) == Qtrue) {
+          htmlSafe = 2;
         }
     }
     if (!indentString) {
@@ -1356,6 +1361,7 @@ void Init_yajl() {
     sym_pretty = ID2SYM(rb_intern("pretty"));
     sym_indent = ID2SYM(rb_intern("indent"));
     sym_html_safe = ID2SYM(rb_intern("html_safe"));
+    sym_entities = ID2SYM(rb_intern("entities"));
     sym_terminator = ID2SYM(rb_intern("terminator"));
     sym_symbolize_keys = ID2SYM(rb_intern("symbolize_keys"));
     sym_symbolize_names = ID2SYM(rb_intern("symbolize_names"));

--- a/ext/yajl/yajl_ext.h
+++ b/ext/yajl/yajl_ext.h
@@ -56,7 +56,7 @@ static rb_encoding *utf8Encoding;
 static VALUE cStandardError, cParseError, cEncodeError, mYajl, cParser, cProjector, cEncoder;
 static ID intern_io_read, intern_call, intern_keys, intern_to_s,
             intern_to_json, intern_has_key, intern_to_sym, intern_as_json;
-static ID sym_allow_comments, sym_check_utf8, sym_pretty, sym_indent, sym_terminator, sym_symbolize_keys, sym_symbolize_names, sym_html_safe;
+static ID sym_allow_comments, sym_check_utf8, sym_pretty, sym_indent, sym_terminator, sym_symbolize_keys, sym_symbolize_names, sym_html_safe, sym_entities;
 
 #define GetParser(obj, sval) Data_Get_Struct(obj, yajl_parser_wrapper, sval);
 #define GetEncoder(obj, sval) Data_Get_Struct(obj, yajl_encoder_wrapper, sval);

--- a/spec/encoding/encoding_spec.rb
+++ b/spec/encoding/encoding_spec.rb
@@ -275,9 +275,25 @@ describe "Yajl JSON encoder" do
     expect(safe_encoder.encode("</script>")).to eql("\"<\\/script>\"")
   end
 
+  it "should not encode characters with entities by default" do
+    expect(Yajl.dump("\u2028\u2029><&")).to eql("\"\u2028\u2029><&\"")
+  end
+
+  it "should encode characters with entities when enabled" do
+    expect(Yajl.dump("\u2028\u2029><&", entities: true)).to eql("\"\\u2028\\u2029\\u003E\\u003C\\u0026\"")
+  end
+
   it "should default to *not* escaping / characters" do
     unsafe_encoder = Yajl::Encoder.new
     expect(unsafe_encoder.encode("</script>")).not_to eql("\"<\\/script>\"")
+  end
+
+  it "should encode slashes when enabled" do
+    unsafe_encoder = Yajl::Encoder.new(:entities => false)
+    safe_encoder   = Yajl::Encoder.new(:entities => true)
+
+    expect(unsafe_encoder.encode("</script>")).not_to eql("\"<\\/script>\"")
+    expect(safe_encoder.encode("</script>")).to eql("\"\\u003C\\/script\\u003E\"")
   end
 
   it "return value of #to_json must be a string" do


### PR DESCRIPTION
This adds a feature to support entity encoding to escape characters that
can be used XSS attacks. This is to match the behavior in
ActiveSupport::JSON. The purpose of matching AS::JSON behavior is so we
can replace it with Yajl so we can use the faster version.

Worked on this with @tenderlove to add the same support we have in [ActiveSupport::JSON](https://github.com/rails/rails/blob/124c082d43688040c43f4e4f9ea9f15fdcbec080/activesupport/lib/active_support/json/encoding.rb#L42-L48)

cc/ @rafaelfranca @jeremy
cc/ @brianmario 