### PR TITLE
docs: fix simple typo, enitity -> entity

### DIFF
--- a/ext/yajl/yajl_parser.c
+++ b/ext/yajl/yajl_parser.c
@@ -161,7 +161,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
             /* for arrays and maps, we advance the state for this
              * depth, then push the state of the next depth.
              * If an error occurs during the parsing of the nesting
-             * enitity, the state at this level will not matter.
+             * entity, the state at this level will not matter.
              * a state that needs pushing will be anything other
              * than state_start */
             yajl_state stateToPush = yajl_state_start;


### PR DESCRIPTION
There is a small typo in ext/yajl/yajl_parser.c.

Should read `entity` rather than `enitity`.

