### PR TITLE
Fix off-by-one in yajl_ext.c

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -847,7 +847,7 @@ static VALUE rb_yajl_projector_build_simple_value(yajl_event_stream_t parser, ya
         case yajl_tok_bool:;
             if (memcmp(event.buf, "true", 4) == 0) {
                 return Qtrue;
-            } else if (memcmp(event.buf, "false", 4) == 0) {
+            } else if (memcmp(event.buf, "false", 5) == 0) {
                 return Qfalse;
             } else {
                 rb_raise(cStandardError, "unknown boolean token %s", event.buf);


### PR DESCRIPTION
The `"false"` string has a length of 5 but we currently compare only 4 bytes.

This was found with a "cstrnfinder" research and I haven't tested this change (more info https://twitter.com/disconnect3d_pl/status/1339757359896408065). Close this PR if this change is incorrect.