### PR TITLE
Faster generation of Symbols, Fixnums, and Hashes

### DIFF
--- a/ext/yajl/api/yajl_gen.h
+++ b/ext/yajl/api/yajl_gen.h
@@ -129,6 +129,7 @@ extern "C" {
      *  NaN, as these have no representation in JSON.  In these cases the
      *  generator will return 'yajl_gen_invalid_number' */
     YAJL_API yajl_gen_status yajl_gen_double(yajl_gen hand, double number);
+    YAJL_API yajl_gen_status yajl_gen_long(yajl_gen hand, long value);
     YAJL_API yajl_gen_status yajl_gen_number(yajl_gen hand,
                                              const char * num,
                                              unsigned int len);

--- a/ext/yajl/yajl_gen.c
+++ b/ext/yajl/yajl_gen.c
@@ -231,6 +231,36 @@ yajl_gen_double(yajl_gen g, double number)
 }
 
 yajl_gen_status
+yajl_gen_long(yajl_gen g, long val)
+{
+    char buf[32], *b = buf + sizeof buf;
+    unsigned int len = 0;
+    unsigned long uval;
+
+    ENSURE_VALID_STATE; ENSURE_NOT_KEY; INSERT_SEP; INSERT_WHITESPACE;
+
+    if (val < 0) {
+        g->print(g->ctx, "-", 1);
+        // Avoid overflow. This shouldn't happen because FIXNUMs are 1 bit less
+        // than LONGs, but good to be safe.
+        uval = 1 + (unsigned long)(-(val + 1));
+    } else {
+        uval = val;
+    }
+
+    do {
+        *--b = "0123456789"[uval % 10];
+        uval /= 10;
+        len++;
+    } while(uval);
+    g->print(g->ctx, b, len);
+
+    APPENDED_ATOM;
+    FINAL_NEWLINE;
+    return yajl_gen_status_ok;
+}
+
+yajl_gen_status
 yajl_gen_number(yajl_gen g, const char * s, unsigned int l)
 {
     ENSURE_VALID_STATE; ENSURE_NOT_KEY; INSERT_SEP; INSERT_WHITESPACE;

--- a/spec/encoding/encoding_spec.rb
+++ b/spec/encoding/encoding_spec.rb
@@ -230,6 +230,16 @@ describe "Yajl JSON encoder" do
     expect(s.read).to eql("{\"foo\":\"bar\"}")
   end
 
+  it "should encode all integers correctly" do
+    0.upto(129).each do |b|
+      b = 1 << b
+      [b, b-1, b-2, b+1, b+2].each do |i|
+        expect(Yajl::Encoder.encode(i)).to eq(i.to_s)
+        expect(Yajl::Encoder.encode(-i)).to eq((-i).to_s)
+      end
+    end
+  end
+
   it "should not encode NaN" do
     expect {
       Yajl::Encoder.encode(0.0/0.0)


### PR DESCRIPTION
This improves the JSON generation speed of Symbols, Fixnums, and Hashes.

Symbols are made faster by checking for `T_SYMBOL` and calling `rb_sym2str` instead of calling Symbol#to_s. This avoids a string allocation and a method lookup.

Fixnums are made faster by writing our own simple itoa (to a buffer on the stack). This avoids a string allocation, method lookup, and might be a tiny bit faster since the radix is hardcoded.

Hashes are improved by avoiding calling to_s on the keys when we have a String or Symbol, and calling `rb_hash_foreach` instead of iterating over keys and using `rb_hash_aref`. This avoids a few method lookups and allocations.

In my quick test run of `benchmark/encode.rb` this was approximately 30% faster.

Before
```
                                         user     system      total        real
Yajl::Encoder#encode (to a String)   1.471238   0.000000   1.471238 (  1.471873)
```



After
```
                                         user     system      total        real
Yajl::Encoder#encode (to a String)   0.902834   0.000000   0.902834 (  0.903391)
```