### PR TITLE
Add support for ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby_version: [2.6.x, 2.7.x]
+        ruby_version: [2.6.x, 2.7.x, 3.0.x]
       fail-fast: false
     runs-on: ubuntu-latest
     name: Test on Ruby ${{ matrix.ruby_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,9 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
     - name: Install dependencies
       run: bundle install
+    - name: Build gem
+      run: gem build yajl-ruby.gemspec
+    - name: Install gem
+      run: gem install yajl-ruby
     - name: Run tests
       run: bundle exec rake spec

--- a/yajl-ruby.gemspec
+++ b/yajl-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.4.2}
   s.summary = %q{Ruby C bindings to the excellent Yajl JSON stream-based parser library.}
   s.test_files = `git ls-files spec examples`.split("\n")
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.6.0"
 
   # tests
   s.add_development_dependency 'rake-compiler'


### PR DESCRIPTION
**Add support for ruby 3, drop support for older rubies**

* Rubies below 2.6 are EOL, 2.6 only supports security releases so this
change drops support for older rubies in the gemspec and adds CI support
for 3.0.x.

**Add gem build and install steps to CI**

* I think this is a Ruby 3.0 issue...locally I had to build and install
the gem for the spec/parsing/large_number_spec.rb tests to pass. They
were failing to find `yajl` in the `require` call. I reproduced this in
the console as well. I believe this has to do with changes to bundler in
Ruby 3.0 but I'm not 100% sure.
