### PR TITLE
Fix c warnings

### DIFF
--- a/ext/yajl/api/yajl_gen.h
+++ b/ext/yajl/api/yajl_gen.h
@@ -63,7 +63,9 @@ extern "C" {
         yajl_gen_invalid_number,
         /** A print callback was passed in, so there is no internal
          * buffer to get from */
-        yajl_gen_no_buf
+        yajl_gen_no_buf,
+        /** Tried to decrement at depth 0 */
+        yajl_depth_underflow
     } yajl_gen_status;
 
     /** an opaque handle to a generator */

--- a/ext/yajl/yajl_gen.c
+++ b/ext/yajl/yajl_gen.c
@@ -178,7 +178,7 @@ yajl_gen_free(yajl_gen g)
     if (++(g->depth) >= YAJL_MAX_DEPTH) return yajl_max_depth_exceeded;
 
 #define DECREMENT_DEPTH \
-    if (--(g->depth) >= YAJL_MAX_DEPTH) return yajl_gen_error;
+    if (--(g->depth) >= YAJL_MAX_DEPTH) return yajl_depth_underflow;
 
 #define APPENDED_ATOM \
     switch (g->state[g->depth]) {                   \

--- a/ext/yajl/yajl_lex.c
+++ b/ext/yajl/yajl_lex.c
@@ -43,6 +43,7 @@ const char *yajl_tok_name(yajl_tok tok) {
         case yajl_tok_bool: return "bool";
         case yajl_tok_colon: return "colon";
         case yajl_tok_comma: return "comma";
+        case yajl_tok_comment: return "comment";
         case yajl_tok_eof: return "eof";
         case yajl_tok_error: return "error";
         case yajl_tok_left_brace: return "open_array";


### PR DESCRIPTION
**Fix implicit conversion from enumeration type warning**
`yajl_gen_error` is a `yajl_gen_state` not a `yajl_gen_status`.
This change adds a new value to the enum for an error when the
decremented depth is too low.

Warnings:

```
../../../../ext/yajl/yajl_gen.c:295:5: warning: implicit conversion from enumeration type 'yajl_gen_state' to different enumeration type 'yajl_gen_status'
      [-Wenum-conversion]
    DECREMENT_DEPTH;
    ^~~~~~~~~~~~~~~
../../../../ext/yajl/yajl_gen.c:181:48: note: expanded from macro 'DECREMENT_DEPTH'
    if (--(g->depth) >= YAJL_MAX_DEPTH) return yajl_gen_error;
                                        ~~~~~~ ^~~~~~~~~~~~~~
../../../../ext/yajl/yajl_gen.c:321:5: warning: implicit conversion from enumeration type 'yajl_gen_state' to different enumeration type 'yajl_gen_status'
      [-Wenum-conversion]
    DECREMENT_DEPTH;
    ^~~~~~~~~~~~~~~
../../../../ext/yajl/yajl_gen.c:181:48: note: expanded from macro 'DECREMENT_DEPTH'
    if (--(g->depth) >= YAJL_MAX_DEPTH) return yajl_gen_error;
                                        ~~~~~~ ^~~~~~~~~~~~~~
```

---

**Fix missing switch case**
`yajl_tok_comment` was not present in the switch case.

Warnings:

```
compiling ../../../../ext/yajl/yajl_lex.c
../../../../ext/yajl/yajl_lex.c:42:13: warning: enumeration value 'yajl_tok_comment' not handled in switch [-Wswitch]
    switch (tok) {
            ^
../../../../ext/yajl/yajl_lex.c:42:13: note: add missing switch cases
    switch (tok) {
            ^
```

