### PR TITLE
Update gemspec file to recent styles

### DIFF
--- a/yajl-ruby.gemspec
+++ b/yajl-ruby.gemspec
@@ -5,15 +5,12 @@ Gem::Specification.new do |s|
   s.version = Yajl::VERSION
   s.license = "MIT"
   s.authors = ["Brian Lopez", "Lloyd Hilaiel"]
-  s.date = Time.now.utc.strftime("%Y-%m-%d")
   s.email = %q{seniorlopez@gmail.com}
   s.extensions = ["ext/yajl/extconf.rb"]
   s.files = `git ls-files`.split("\n")
-  s.homepage = %q{http://github.com/brianmario/yajl-ruby}
+  s.homepage = %q{https://github.com/brianmario/yajl-ruby}
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.4.2}
   s.summary = %q{Ruby C bindings to the excellent Yajl JSON stream-based parser library.}
-  s.test_files = `git ls-files spec examples`.split("\n")
   s.required_ruby_version = ">= 2.6.0"
 
   # tests


### PR DESCRIPTION
This PR updates `yajl-ruby.gemspec` to recent styles. Here are the details:
- `date` and `rubygems_version` should not be set
  - RubyGems says not to set the value to [`date`](https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L1677-L1682) and [`rubygems_version`](https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L536-L541).
- Remove deprecated `test_files`
  - Please see the following for details.
    -  rubygems/guides#90
    - rubygems/bundler#3207
- Update homepage to https
  - This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/yajl-ruby or some tools or APIs that use the gem's metadata.