### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,17 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby_version: [2.6.x, 2.7.x, 3.0.x]
+        ruby_version: ['2.6', '2.7', '3.0', '3.1']
       fail-fast: false
     runs-on: ubuntu-latest
     name: Test on Ruby ${{ matrix.ruby_version }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Ruby ${{ matrix.ruby_version }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true
     - name: Build gem
       run: gem build yajl-ruby.gemspec
     - name: Install gem


### PR DESCRIPTION
- Update actions/checkout from v2 to v3
- Use ruby/setup-ruby instead of actions/setup-ruby
  - Enclose all `ruby_version`s with quotes to avoid the following issue:
    https://github.com/ruby/setup-ruby/issues/252
  - Add Ruby 3.1 to the CI matrix
  - Enable `bundler-cache` to cache gem dependencies