### PR TITLE
It resolves the cannot load such file -- ./lib/recursive_open_struct/version issue

### DIFF
--- a/yajl-ruby.gemspec
+++ b/yajl-ruby.gemspec
@@ -1,4 +1,6 @@
-require './lib/yajl/version'
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'yajl/version'
 
 Gem::Specification.new do |s|
   s.name = %q{yajl-ruby}


### PR DESCRIPTION
I am getting this error while adding add gem to vendor set 
```
Invalid gemspec in [/Users/vjagdale/.inspec/gems/3.0.0/gems/recursive-open-struct-1.1.3/recursive-open-struct.gemspec]: cannot load such file -- ./lib/recursive_open_struct/version
```

Adding the below lines to gemspec file resolves the issue.
```l
ib = File.expand_path('lib', __dir__)
$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
require 'yajl/version'
```