### PR TITLE
Fix build error with gcc 15

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -1352,18 +1352,18 @@ static VALUE rb_yajl_json_ext_nil_to_json(int argc, VALUE * argv, VALUE self) {
  * Enables the JSON gem compatibility API
  */
 static VALUE rb_yajl_encoder_enable_json_gem_ext(VALUE klass) {
-    rb_define_method(rb_cHash, "to_json", rb_yajl_json_ext_hash_to_json, -1);
-    rb_define_method(rb_cArray, "to_json", rb_yajl_json_ext_array_to_json, -1);
+    rb_define_method(rb_cHash, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_hash_to_json), -1);
+    rb_define_method(rb_cArray, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_array_to_json), -1);
 #ifdef RUBY_INTEGER_UNIFICATION
-    rb_define_method(rb_cInteger, "to_json", rb_yajl_json_ext_fixnum_to_json, -1);
+    rb_define_method(rb_cInteger, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_fixnum_to_json), -1);
 #else
-    rb_define_method(rb_cFixnum, "to_json", rb_yajl_json_ext_fixnum_to_json, -1);
+    rb_define_method(rb_cFixnum, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_fixnum_to_json), -1);
 #endif
-    rb_define_method(rb_cFloat, "to_json", rb_yajl_json_ext_float_to_json, -1);
-    rb_define_method(rb_cString, "to_json", rb_yajl_json_ext_string_to_json, -1);
-    rb_define_method(rb_cTrueClass, "to_json", rb_yajl_json_ext_true_to_json, -1);
-    rb_define_method(rb_cFalseClass, "to_json", rb_yajl_json_ext_false_to_json, -1);
-    rb_define_method(rb_cNilClass, "to_json", rb_yajl_json_ext_nil_to_json, -1);
+    rb_define_method(rb_cFloat, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_float_to_json), -1);
+    rb_define_method(rb_cString, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_string_to_json), -1);
+    rb_define_method(rb_cTrueClass, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_true_to_json), -1);
+    rb_define_method(rb_cFalseClass, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_false_to_json), -1);
+    rb_define_method(rb_cNilClass, "to_json", RUBY_METHOD_FUNC(rb_yajl_json_ext_nil_to_json), -1);
     return Qnil;
 }
 
@@ -1380,24 +1380,24 @@ void Init_yajl() {
 
     cParser = rb_define_class_under(mYajl, "Parser", rb_cObject);
     rb_undef_alloc_func(cParser);
-    rb_define_singleton_method(cParser, "new", rb_yajl_parser_new, -1);
-    rb_define_method(cParser, "initialize", rb_yajl_parser_init, -1);
-    rb_define_method(cParser, "parse", rb_yajl_parser_parse, -1);
-    rb_define_method(cParser, "parse_chunk", rb_yajl_parser_parse_chunk, 1);
-    rb_define_method(cParser, "<<", rb_yajl_parser_parse_chunk, 1);
-    rb_define_method(cParser, "on_parse_complete=", rb_yajl_parser_set_complete_cb, 1);
+    rb_define_singleton_method(cParser, "new", RUBY_METHOD_FUNC(rb_yajl_parser_new), -1);
+    rb_define_method(cParser, "initialize", RUBY_METHOD_FUNC(rb_yajl_parser_init), -1);
+    rb_define_method(cParser, "parse", RUBY_METHOD_FUNC(rb_yajl_parser_parse), -1);
+    rb_define_method(cParser, "parse_chunk", RUBY_METHOD_FUNC(rb_yajl_parser_parse_chunk), 1);
+    rb_define_method(cParser, "<<", RUBY_METHOD_FUNC(rb_yajl_parser_parse_chunk), 1);
+    rb_define_method(cParser, "on_parse_complete=", RUBY_METHOD_FUNC(rb_yajl_parser_set_complete_cb), 1);
 
     cProjector = rb_define_class_under(mYajl, "Projector", rb_cObject);
-    rb_define_method(cProjector, "project", rb_yajl_projector_project, 1);
+    rb_define_method(cProjector, "project", RUBY_METHOD_FUNC(rb_yajl_projector_project), 1);
 
     cEncoder = rb_define_class_under(mYajl, "Encoder", rb_cObject);
     rb_undef_alloc_func(cEncoder);
-    rb_define_singleton_method(cEncoder, "new", rb_yajl_encoder_new, -1);
-    rb_define_method(cEncoder, "initialize", rb_yajl_encoder_init, -1);
-    rb_define_method(cEncoder, "encode", rb_yajl_encoder_encode, -1);
-    rb_define_method(cEncoder, "on_progress=", rb_yajl_encoder_set_progress_cb, 1);
+    rb_define_singleton_method(cEncoder, "new", RUBY_METHOD_FUNC(rb_yajl_encoder_new), -1);
+    rb_define_method(cEncoder, "initialize", RUBY_METHOD_FUNC(rb_yajl_encoder_init), -1);
+    rb_define_method(cEncoder, "encode", RUBY_METHOD_FUNC(rb_yajl_encoder_encode), -1);
+    rb_define_method(cEncoder, "on_progress=", RUBY_METHOD_FUNC(rb_yajl_encoder_set_progress_cb), 1);
 
-    rb_define_singleton_method(cEncoder, "enable_json_gem_compatability", rb_yajl_encoder_enable_json_gem_ext, 0);
+    rb_define_singleton_method(cEncoder, "enable_json_gem_compatability", RUBY_METHOD_FUNC(rb_yajl_encoder_enable_json_gem_ext), 0);
 
     intern_io_read = rb_intern("read");
     intern_call = rb_intern("call");


### PR DESCRIPTION
This patch will fix following build error with GCC 15 on Windows:

```
PS C:\src\yajl-ruby\ext\yajl> ridk exec make
generating yajl-x64-mingw-ucrt.def
compiling yajl.c
yajl.c: In function 'yajl_status_to_string':
yajl.c:64:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
   64 | }
      | ^
yajl.c: In function 'yajl_alloc':
yajl.c:116:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  116 | }
      | ^
yajl.c: In function 'yajl_reset_parser':
yajl.c:122:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  122 | }
      | ^
yajl.c: In function 'yajl_free':
yajl.c:132:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  132 | }
      | ^
yajl.c: In function 'yajl_parse':
yajl.c:142:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  142 | }
      | ^
yajl.c: In function 'yajl_parse_complete':
yajl.c:155:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  155 | }
      | ^
yajl.c: In function 'yajl_get_error':
yajl.c:163:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  163 | }
      | ^
yajl.c: In function 'yajl_get_bytes_consumed':
yajl.c:170:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  170 | }
      | ^
yajl.c: In function 'yajl_free_error':
yajl.c:178:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  178 | }
      | ^
compiling yajl_alloc.c
yajl_alloc.c: In function 'yajl_set_default_alloc_funcs':
yajl_alloc.c:64:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
   64 | }
      | ^
compiling yajl_buf.c
yajl_buf.c: In function 'yajl_buf_alloc':
yajl_buf.c:149:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  149 | }
      | ^
yajl_buf.c: In function 'yajl_buf_free':
yajl_buf.c:156:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  156 | }
      | ^
yajl_buf.c: In function 'yajl_buf_append':
yajl_buf.c:169:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  169 | }
      | ^
yajl_buf.c: In function 'yajl_buf_clear':
yajl_buf.c:177:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  177 | }
      | ^
yajl_buf.c: In function 'yajl_buf_data':
yajl_buf.c:184:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  184 | }
      | ^
yajl_buf.c: In function 'yajl_buf_len':
yajl_buf.c:191:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  191 | }
      | ^
yajl_buf.c: In function 'yajl_buf_truncate':
yajl_buf.c:200:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  200 | }
      | ^
compiling yajl_encode.c
yajl_encode.c: In function 'yajl_string_encode2':
yajl_encode.c:135:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  135 | }
      | ^
yajl_encode.c: In function 'yajl_string_encode':
yajl_encode.c:52:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
   52 | }
      | ^
yajl_encode.c: In function 'yajl_string_decode':
yajl_encode.c:237:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  237 | }
      | ^
compiling yajl_ext.c
yajl_ext.c: In function 'yajl_check_and_fire_callback':
yajl_ext.c:63:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
   63 |     GetParser((VALUE)ctx, wrapper);
      |     ^~~~~~~~~
In file included from C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core.h:27,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/ruby.h:29,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby.h:38,
                 from yajl_ext.h:32,
                 from yajl_ext.c:24:
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'yajl_set_static_value':
yajl_ext.c:110:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  110 |     GetParser((VALUE)ctx, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'yajl_found_hash_key':
yajl_ext.c:380:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  380 |     GetParser((VALUE)ctx, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'yajl_found_start_hash':
yajl_ext.c:409:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  409 |     GetParser((VALUE)ctx, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'yajl_found_end_hash':
yajl_ext.c:417:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  417 |     GetParser((VALUE)ctx, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'yajl_found_start_array':
yajl_ext.c:428:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  428 |     GetParser((VALUE)ctx, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'yajl_found_end_array':
yajl_ext.c:436:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  436 |     GetParser((VALUE)ctx, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'rb_yajl_parser_parse':
yajl_ext.c:544:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  544 |     GetParser(self, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/dosish.h:38,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/defines.h:78,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/ruby.h:25:
C:/Ruby34-x64/include/ruby-3.4.0/ruby/win32.h:196:14: warning: variable 'stati128' set but not used [-Wunused-but-set-variable]
  196 | #define stat stati128
      |              ^~~~~~~~
yajl_ext.c:538:17: note: in expansion of macro 'stat'
  538 |     yajl_status stat;
      |                 ^~~~
yajl_ext.c: In function 'rb_yajl_parser_parse_chunk':
yajl_ext.c:598:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  598 |     GetParser(self, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'rb_yajl_parser_set_complete_cb':
yajl_ext.c:625:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  625 |     GetParser(self, wrapper);
      |     ^~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'rb_yajl_encoder_encode':
yajl_ext.c:1152:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
 1152 |     GetEncoder(self, wrapper);
      |     ^~~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'rb_yajl_encoder_set_progress_cb':
yajl_ext.c:1208:5: warning: 'rb_data_object_get_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
 1208 |     GetEncoder(self, wrapper);
      |     ^~~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'rb_yajl_encoder_enable_json_gem_ext':
yajl_ext.c:1355:43: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1355 |     rb_define_method(rb_cHash, "to_json", rb_yajl_json_ext_hash_to_json, -1);
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                           |
      |                                           VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
In file included from C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/anyargs.h:78,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/ruby.h:27:
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1228:14: note: 'rb_yajl_json_ext_hash_to_json' declared here
 1228 | static VALUE rb_yajl_json_ext_hash_to_json(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1356:44: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1356 |     rb_define_method(rb_cArray, "to_json", rb_yajl_json_ext_array_to_json, -1);
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                            |
      |                                            VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1244:14: note: 'rb_yajl_json_ext_array_to_json' declared here
 1244 | static VALUE rb_yajl_json_ext_array_to_json(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1358:46: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1358 |     rb_define_method(rb_cInteger, "to_json", rb_yajl_json_ext_fixnum_to_json, -1);
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                              |
      |                                              VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1260:14: note: 'rb_yajl_json_ext_fixnum_to_json' declared here
 1260 | static VALUE rb_yajl_json_ext_fixnum_to_json(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1362:44: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1362 |     rb_define_method(rb_cFloat, "to_json", rb_yajl_json_ext_float_to_json, -1);
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                            |
      |                                            VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1276:14: note: 'rb_yajl_json_ext_float_to_json' declared here
 1276 | static VALUE rb_yajl_json_ext_float_to_json(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1363:45: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1363 |     rb_define_method(rb_cString, "to_json", rb_yajl_json_ext_string_to_json, -1);
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                             |
      |                                             VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1292:14: note: 'rb_yajl_json_ext_string_to_json' declared here
 1292 | static VALUE rb_yajl_json_ext_string_to_json(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1364:48: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1364 |     rb_define_method(rb_cTrueClass, "to_json", rb_yajl_json_ext_true_to_json, -1);
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                |
      |                                                VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1308:14: note: 'rb_yajl_json_ext_true_to_json' declared here
 1308 | static VALUE rb_yajl_json_ext_true_to_json(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1365:49: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1365 |     rb_define_method(rb_cFalseClass, "to_json", rb_yajl_json_ext_false_to_json, -1);
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                 |
      |                                                 VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1324:14: note: 'rb_yajl_json_ext_false_to_json' declared here
 1324 | static VALUE rb_yajl_json_ext_false_to_json(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1366:47: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1366 |     rb_define_method(rb_cNilClass, "to_json", rb_yajl_json_ext_nil_to_json, -1);
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1340:14: note: 'rb_yajl_json_ext_nil_to_json' declared here
 1340 | static VALUE rb_yajl_json_ext_nil_to_json(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c: In function 'Init_yajl':
yajl_ext.c:1383:48: error: passing argument 3 of 'rb_define_singleton_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1383 |     rb_define_singleton_method(cParser, "new", rb_yajl_parser_new, -1);
      |                                                ^~~~~~~~~~~~~~~~~~
      |                                                |
      |                                                VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
In file included from C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/anyargs.h:76:
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/intern/class.h:365:68: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
  365 | void rb_define_singleton_method(VALUE obj, const char *mid, VALUE(*func)(ANYARGS), int arity);
      |                                                             ~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:467:14: note: 'rb_yajl_parser_new' declared here
  467 | static VALUE rb_yajl_parser_new(int argc, VALUE * argv, VALUE klass) {
      |              ^~~~~~~~~~~~~~~~~~
yajl_ext.c:1384:45: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1384 |     rb_define_method(cParser, "initialize", rb_yajl_parser_init, -1);
      |                                             ^~~~~~~~~~~~~~~~~~~
      |                                             |
      |                                             VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:512:14: note: 'rb_yajl_parser_init' declared here
  512 | static VALUE rb_yajl_parser_init(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~
yajl_ext.c:1385:40: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1385 |     rb_define_method(cParser, "parse", rb_yajl_parser_parse, -1);
      |                                        ^~~~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:537:14: note: 'rb_yajl_parser_parse' declared here
  537 | static VALUE rb_yajl_parser_parse(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1386:46: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1386 |     rb_define_method(cParser, "parse_chunk", rb_yajl_parser_parse_chunk, 1);
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                              |
      |                                              VALUE (*)(VALUE,  VALUE) {aka long long unsigned int (*)(long long unsigned int,  long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(VALUE,  VALUE)' {aka 'long long unsigned int (*)(long long unsigned int,  long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:594:14: note: 'rb_yajl_parser_parse_chunk' declared here
  594 | static VALUE rb_yajl_parser_parse_chunk(VALUE self, VALUE chunk) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1387:37: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1387 |     rb_define_method(cParser, "<<", rb_yajl_parser_parse_chunk, 1);
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                     |
      |                                     VALUE (*)(VALUE,  VALUE) {aka long long unsigned int (*)(long long unsigned int,  long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(VALUE,  VALUE)' {aka 'long long unsigned int (*)(long long unsigned int,  long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:594:14: note: 'rb_yajl_parser_parse_chunk' declared here
  594 | static VALUE rb_yajl_parser_parse_chunk(VALUE self, VALUE chunk) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1388:53: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1388 |     rb_define_method(cParser, "on_parse_complete=", rb_yajl_parser_set_complete_cb, 1);
      |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                     |
      |                                                     VALUE (*)(VALUE,  VALUE) {aka long long unsigned int (*)(long long unsigned int,  long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(VALUE,  VALUE)' {aka 'long long unsigned int (*)(long long unsigned int,  long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:623:14: note: 'rb_yajl_parser_set_complete_cb' declared here
  623 | static VALUE rb_yajl_parser_set_complete_cb(VALUE self, VALUE callback) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1391:45: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1391 |     rb_define_method(cProjector, "project", rb_yajl_projector_project, 1);
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                                             |
      |                                             VALUE (*)(VALUE,  VALUE) {aka long long unsigned int (*)(long long unsigned int,  long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(VALUE,  VALUE)' {aka 'long long unsigned int (*)(long long unsigned int,  long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:985:14: note: 'rb_yajl_projector_project' declared here
  985 | static VALUE rb_yajl_projector_project(VALUE self, VALUE schema) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1395:49: error: passing argument 3 of 'rb_define_singleton_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1395 |     rb_define_singleton_method(cEncoder, "new", rb_yajl_encoder_new, -1);
      |                                                 ^~~~~~~~~~~~~~~~~~~
      |                                                 |
      |                                                 VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/intern/class.h:365:68: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
  365 | void rb_define_singleton_method(VALUE obj, const char *mid, VALUE(*func)(ANYARGS), int arity);
      |                                                             ~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1053:14: note: 'rb_yajl_encoder_new' declared here
 1053 | static VALUE rb_yajl_encoder_new(int argc, VALUE * argv, VALUE klass) {
      |              ^~~~~~~~~~~~~~~~~~~
yajl_ext.c:1396:46: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1396 |     rb_define_method(cEncoder, "initialize", rb_yajl_encoder_init, -1);
      |                                              ^~~~~~~~~~~~~~~~~~~~
      |                                              |
      |                                              VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1125:14: note: 'rb_yajl_encoder_init' declared here
 1125 | static VALUE rb_yajl_encoder_init(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1397:42: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1397 |     rb_define_method(cEncoder, "encode", rb_yajl_encoder_encode, -1);
      |                                          ^~~~~~~~~~~~~~~~~~~~~~
      |                                          |
      |                                          VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1145:14: note: 'rb_yajl_encoder_encode' declared here
 1145 | static VALUE rb_yajl_encoder_encode(int argc, VALUE * argv, VALUE self) {
      |              ^~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1398:48: error: passing argument 3 of 'rb_define_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1398 |     rb_define_method(cEncoder, "on_progress=", rb_yajl_encoder_set_progress_cb, 1);
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                |
      |                                                VALUE (*)(VALUE,  VALUE) {aka long long unsigned int (*)(long long unsigned int,  long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:99:61: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(VALUE,  VALUE)' {aka 'long long unsigned int (*)(long long unsigned int,  long long unsigned int)'}
   99 | void rb_define_method(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                     ~~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1206:14: note: 'rb_yajl_encoder_set_progress_cb' declared here
 1206 | static VALUE rb_yajl_encoder_set_progress_cb(VALUE self, VALUE callback) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
yajl_ext.c:1400:75: error: passing argument 3 of 'rb_define_singleton_method' from incompatible pointer type [-Wincompatible-pointer-types]
 1400 |     rb_define_singleton_method(cEncoder, "enable_json_gem_compatability", rb_yajl_encoder_enable_json_gem_ext, 0);
      |                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                           |
      |                                                                           VALUE (*)(VALUE) {aka long long unsigned int (*)(long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/intern/class.h:365:68: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(VALUE)' {aka 'long long unsigned int (*)(long long unsigned int)'}
  365 | void rb_define_singleton_method(VALUE obj, const char *mid, VALUE(*func)(ANYARGS), int arity);
      |                                                             ~~~~~~~^~~~~~~~~~~~~~
yajl_ext.c:1354:14: note: 'rb_yajl_encoder_enable_json_gem_ext' declared here
 1354 | static VALUE rb_yajl_encoder_enable_json_gem_ext(VALUE klass) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:251: yajl_ext.o] エラー 1
```

Related to https://github.com/fluent/fluentd/issues/4938