### PR TITLE
fix off-by-one read in yajl_string_encode2 separator escaping

### DIFF
--- a/ext/yajl/yajl_encode.c
+++ b/ext/yajl/yajl_encode.c
@@ -89,7 +89,7 @@ yajl_string_encode2(const yajl_print_t print,
             /* Escaping 0xe280a8 0xe280a9 */
             case 0xe2:
               if (htmlSafe == 2) {
-                  if (len - end >= 2 && str[end + 1] == 0x80) {
+                  if (len - end >= 3 && str[end + 1] == 0x80) {
                       if (str[end + 2] == 0xa8) {
                           increment = 3;
                           entityBuffer[4] = '2';


### PR DESCRIPTION
When :entities is set, the 0xe2 branch guards with `len - end >= 2` but then reads `str[end + 2]`, so a buffer ending in the bytes 0xe2 0x80 is read one past the end. With the input placed flush against a guard page:

    yajl_encode.c:93  read of str[end + 2]  ->  SIGBUS (1 byte past buffer)

Matching the U+2028/U+2029 sequence needs 3 bytes available, not 2.