### PR TITLE
use rb_ary_entry in yajl_encode_part to avoid stale RARRAY_PTR

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -239,9 +239,8 @@ void yajl_encode_part(void * wrapper, VALUE obj, VALUE io) {
         case T_ARRAY:
             CHECK_STATUS(yajl_gen_array_open(w->encoder));
 
-	    VALUE *ptr = RARRAY_PTR(obj);
             for(idx=0; idx<RARRAY_LEN(obj); idx++) {
-                yajl_encode_part(w, ptr[idx], io);
+                yajl_encode_part(w, rb_ary_entry(obj, idx), io);
             }
             CHECK_STATUS(yajl_gen_array_close(w->encoder));
             break;


### PR DESCRIPTION
Noticed the T_ARRAY case in yajl_encode_part caches `VALUE *ptr = RARRAY_PTR(obj)` and then walks `ptr[idx]`. But each element can run Ruby (a member's to_s/to_json, or the on_progress block during a buffer flush); if that grows the same array its backing store is reallocated and `ptr` dangles, so the next `ptr[idx]` reads freed memory and segfaults. Reading through `rb_ary_entry(obj, idx)` hits the live buffer each pass and is bounds-checked.