### PR TITLE
Use append_cflags for GCC-specific warning flags

### DIFF
--- a/ext/yajl/extconf.rb
+++ b/ext/yajl/extconf.rb
@@ -1,7 +1,7 @@
 require 'mkmf'
 require 'rbconfig'
 
-$CFLAGS << ' -Wall -funroll-loops -Wno-declaration-after-statement'
+append_cflags(%w[-Wall -funroll-loops -Wno-declaration-after-statement])
 $CFLAGS << ' -Werror-implicit-function-declaration -Wextra -O0 -ggdb3' if ENV['DEBUG']
 
 if ENV['SANITIZE']


### PR DESCRIPTION
The extconf.rb unconditionally appended -Wall -funroll-loops -Wno-declaration-after-statement to $CFLAGS. These are GCC and clang flags, so building the gem from source on x64-mswin64 with MSVC failed with command line error D8021 because cl.exe cannot parse -Wno-declaration-after-statement.

This switches to append_cflags, which probes each flag and keeps only the ones the active compiler accepts. On GCC and clang all three flags are still applied, so those builds are unchanged. On MSVC only -Wall survives and the source build succeeds. The vendored yajl C sources themselves need no MSVC changes.

    gem install yajl-ruby --platform ruby

now builds with nmake and cl, and Yajl::Parser.parse(Yajl::Encoder.encode({"a" => 1})) works on the resulting install.
